### PR TITLE
Resolved issue in sending WM_DESTROY msg to ActiveX controls

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.cs
@@ -3203,8 +3203,9 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
 
     private unsafe void DetachAndForward(ref Message m)
     {
+        bool isHandleCreated = IsHandleCreated;
         DetachWindow();
-        if (IsHandleCreated)
+        if (isHandleCreated)
         {
             void* wndProc = (void*)PInvokeCore.GetWindowLong(this, WINDOW_LONG_PTR_INDEX.GWL_WNDPROC);
             m.ResultInternal = PInvokeCore.CallWindowProc(


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12551


## Proposed changes

-  The `DetachWindow` method always sets `IsHandleCreated` to false. This causes the if condition to always be false, preventing the WM_DESTROY message from being sent to ActiveX controls. To fix this, we now store the value of `IsHandleCreated` in a boolean variable before calling the `DetachWindow` method. This was the previous behavior but got disrupted due to [this change](https://github.com/dotnet/winforms/commit/834d0a0d364c82bf70803706886ff9a40bd3e090#diff-dc17cf8f6ef4b80a13b2386597a72cd7ae36cab7375583a0a1e76a62f7f9238fL3556).